### PR TITLE
[Tooling] Standardize podspec format

### DIFF
--- a/NSURL+IDN.podspec
+++ b/NSURL+IDN.podspec
@@ -1,11 +1,18 @@
 Pod::Spec.new do |s|
-  s.name      = 'NSURL+IDN'
-  s.version   = '0.4'
-  s.license   = 'MIT'
-  s.summary   = 'Support for IDN (punycode) in NSURL'
-  s.homepage  = 'https://github.com/wordpress-mobile/NSURL-IDN.git'
-  s.authors    = { 'WordPress' => 'mobile@automattic.com'}
-  s.source    = { :git => 'https://github.com/wordpress-mobile/NSURL-IDN.git' , :tag => '0.3'}
-  s.requires_arc = true
+  s.name          = 'NSURL+IDN'
+  s.version       = '0.4'
+
+  s.summary       = 'Support for IDN (punycode) in NSURL'
+  s.description   = <<-DESC
+                    This micro-library provides support for encoding and decoding URLs which are using Punycode (RFC 3492) to encode hostnames with non-standard Unicode characters.
+
+                    See https://en.wikipedia.org/wiki/Punycode
+                  DESC
+
+  s.homepage      = 'https://github.com/wordpress-mobile/NSURL-IDN'
+  s.license       = { :type => 'MIT', :file => 'LICENSE' }
+  s.author        = { 'The WordPress Mobile Team' => 'mobile@automattic.com' }
+
+  s.source        = { :git => 'https://github.com/wordpress-mobile/NSURL-IDN.git', :tag => s.version.to_s }
   s.source_files = 'NSURL*.{h,m}'
 end

--- a/NSURL+IDN.podspec
+++ b/NSURL+IDN.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
 
   s.homepage      = 'https://github.com/wordpress-mobile/NSURL-IDN'
   s.license       = { :type => 'MIT', :file => 'LICENSE' }
-  s.author        = { 'The WordPress Mobile Team' => 'mobile@automattic.com' }
+  s.author        = { 'The WordPress Mobile Team' => 'mobile@wordpress.org' }
 
   s.source        = { :git => 'https://github.com/wordpress-mobile/NSURL-IDN.git', :tag => s.version.to_s }
   s.source_files = 'NSURL*.{h,m}'


### PR DESCRIPTION
As part of paaHJt-Vl-p2, this simply standardize the podspec file so that all our pods use a similar format and structure, with similar keys and common values.

See wordpress-mobile/WordPressAuthenticator-iOS#582 for the rules I decided to follow on the format and content standardization.

---

### Notes

* This PR targets the `trunk` branch, as this repo doesn't seem to have a `develop` branch.
* In the current podspec published to CocoaPods's trunk and CDN, the `s.version` is `0.4` but the `s.source.tag` was left as `0.3`, leaving it to an inconsistent state
   * This is because unlike most podspecs, this one wasn't configured to have `s.source.tag = s.version.to_s`, but instead had the version hardcoded. And when the https://github.com/wordpress-mobile/NSURL-IDN/pull/6/files PR bumped the version, we forgot to update the tag reference in the `podspec`
   * This shouldn't be a big deal though, because the only difference between tags 0.3 and 0.4 was the update of the Xcode version (to Xcode 11) for the project, so should not affect the pods' own source.
   * Therefore, even if consumers of this lib were pointing to `pod 'NSURL-IDN', '0.4'` in their `Podfile` but got the source code from tag `0.3` because of this, this should not have affected them, since there's no change in the source files in [this 0.3..0.4 diff](https://github.com/wordpress-mobile/NSURL-IDN/compare/0.3...0.4).